### PR TITLE
Ephemeral UDP with port reuse

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -3,12 +3,20 @@ var sys = require('sys')
   , mersenne = require('mersenne')
   , mt = new mersenne.MersenneTwister19937();
 
+const EPHEMERAL_LIFETIME_MS = 1000;
+
 Client = function (host, port, socket) {
     this.host = host;
     this.port = port;
 
     // optional shared socket
     this.socket = socket;
+
+    // when a *shared* socked isn't provided, an ephemeral
+    // socket is demand allocated.  This ephemeral socket is closed
+    // after being idle for EPHEMERAL_LIFETIME_MS.
+    this.ephemeral_socket = undefined;
+    this.last_used_timer = undefined;
 }
 
 Client.prototype.timing = function (stat, time, sample_rate) {
@@ -43,24 +51,39 @@ Client.prototype.update_stats = function (stats, delta, sampleRate) {
     self.send(data, sampleRate);
 }
 
+// An internal function update the last time the socket was
+// used.  This function is called when the socket is used
+// and causes demand allocated ephemeral sockets to be closed
+// after a period of inactivity.
+Client.prototype._update_last_used = function () {
+    if (this.ephemeral_socket) {
+        if (this.last_used_timer) clearTimeout(this.last_used_timer);
+        var self = this;
+        this.last_used_timer = setTimeout(function() {
+            if (self.ephemeral_socket) self.ephemeral_socket.close();
+            delete self.ephemeral_socket;
+        }, EPHEMERAL_LIFETIME_MS);
+    }
+};
+
 Client.prototype.send_data = function (buffer) {
     var self = this;
     var socket;
 
     if (this.socket === undefined) {
-        socket = dgram.createSocket('udp4');
+        if (!this.ephemeral_socket) {
+            this.ephemeral_socket = dgram.createSocket('udp4');
+        }
+        socket = this.ephemeral_socket;
     } else {
         socket = this.socket;
     }
 
+    this._update_last_used();
+
     socket.send(buffer, 0, buffer.length, this.port, this.host, function (err, bytes) {
         if (err) {
             console.log("Error while sending data:", err.msg);
-        }
-
-        if (self.socket === undefined) {
-            // close ephemeral sockets while keeping shared ones open
-            socket.close();
         }
     });
 }

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -1,11 +1,14 @@
 var sys = require('sys')
-  , socket = require('dgram').createSocket('udp4')
+  , dgram = require('dgram')
   , mersenne = require('mersenne')
   , mt = new mersenne.MersenneTwister19937();
 
-Client = function (host, port) {
+Client = function (host, port, socket) {
     this.host = host;
     this.port = port;
+
+    // optional shared socket
+    this.socket = socket;
 }
 
 Client.prototype.timing = function (stat, time, sample_rate) {
@@ -40,6 +43,28 @@ Client.prototype.update_stats = function (stats, delta, sampleRate) {
     self.send(data, sampleRate);
 }
 
+Client.prototype.send_data = function (buffer) {
+    var self = this;
+    var socket;
+
+    if (this.socket === undefined) {
+        socket = dgram.createSocket('udp4');
+    } else {
+        socket = this.socket;
+    }
+
+    socket.send(buffer, 0, buffer.length, this.port, this.host, function (err, bytes) {
+        if (err) {
+            console.log("Error while sending data:", err.msg);
+        }
+
+        if (self.socket === undefined) {
+            // close ephemeral sockets while keeping shared ones open
+            socket.close();
+        }
+    });
+}
+
 Client.prototype.send = function (data, sample_rate) {
     var self = this;
     if (!sample_rate) {
@@ -60,14 +85,7 @@ Client.prototype.send = function (data, sample_rate) {
     }
     for (stat in sampled_data) {
         send_data = stat+":"+sampled_data[stat];
-        send_data = new Buffer(send_data);
-        socket.send(send_data, 0, send_data.length, self.port, self.host,
-                    function (err, bytes) {
-                        if (err) {
-                            console.log(err.msg);
-                        }
-                    }
-                   );
+        this.send_data(new Buffer(send_data));
     }
 };
 


### PR DESCRIPTION
We tested issue #6 (@mojodna's wonderful patch to bind ephemeral UDP ports on demand), under extreme load, and found that resource consumption was very high on certain linuxes when sending lots of UDP traffic.

This is another pull request, built on @mojodna's, that adds a small timeout that leaves ephemerally bound udp ports open and re-uses them when more statsd is invoked more frequently than 1s.  Same extreme load looks a _lot_ better in terms of file descriptor usage.

The approach was suggested by (again) @mojodna in his pull request.
