### PR TITLE
Enable option to cache DNS lookup once

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ $ npm install node-statsd
 
 All initialization parameters are optional.
 
-Parameters:
+Parameters (specified as an options hash):
 * `host`:      The host to send stats to `default: localhost`
 * `port`:      The port to send stats to `default: 8125`
 * `prefix`:    What to prefix each stat name with `default: ''`
 * `suffix`:    What to suffix each stat name with `default: ''`
-* `globalize`: Expost this StatsD instance globally? `default: false`
+* `globalize`: Expose this StatsD instance globally? `default: false`
+* `dnsCache`:  Cache the initial dns lookup to *host* `default: false`
 
 All StatsD methods have the same API:
 * `name`:       Stat name `required`

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -1,22 +1,47 @@
-var dgram = require('dgram');
+var dgram = require('dgram'),
+    dns   = require('dns');
 
 /**
  * The UDP Client for StatsD
- * @param host The host to connect to default: localhost
- * @param port The port to connect to default: 8125
- * @param prefix An optional prefix to assign to each stat name sent
- * @param suffix An optional suffix to assign to each stat name sent
- * @param globalize An optional boolean to add "statsd" as an object in the global namespace
+ * @param options
+ *   @option host      {String}  The host to connect to default: localhost
+ *   @option port      {String|Integer} The port to connect to default: 8125
+ *   @option prefix    {String}  An optional prefix to assign to each stat name sent
+ *   @option suffix    {String}  An optional suffix to assign to each stat name sent
+ *   @option globalize {boolean} An optional boolean to add "statsd" as an object in the global namespace
+ *   @option cacheDns  {boolean} An optional option to only lookup the hostname -> ip address once
  * @constructor
  */
-var Client = function (host, port, prefix, suffix, globalize) {
-  this.host = host || 'localhost';
-  this.port = port || 8125;
-  this.prefix = prefix || '';
-  this.suffix = suffix || '';
+var Client = function (host, port, prefix, suffix, globalize, cacheDns) {
+  var options = host || {},
+         self = this;
+
+  if(arguments.length > 1 || typeof(host) === 'string'){
+    options = {
+      host      : host,
+      port      : port,
+      prefix    : prefix,
+      suffix    : suffix,
+      globalize : globalize,
+      cacheDns  : cacheDns
+    };
+  }
+
+  this.host   = options.host || 'localhost';
+  this.port   = options.port || 8125;
+  this.prefix = options.prefix || '';
+  this.suffix = options.suffix || '';
   this.socket = dgram.createSocket('udp4');
 
-  if(globalize){
+  if(options.cacheDns === true){
+    dns.lookup(options.host, function(err, address, family){
+      if(err == null){
+        self.host = address;
+      }
+    });
+  }
+
+  if(options.globalize){
     global.statsd = this;
   }
 };


### PR DESCRIPTION
Caching the dns lookup leads to significant throughput gains for
non-ip hostnames.  Also, provided a new (backwards compatible) api to allow for easier instantiation of StatsD clients.
