### PR TITLE
Add StatsDNull client. Closes #16.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Parameters (specified as an options hash):
 * `suffix`:    What to suffix each stat name with `default: ''`
 * `globalize`: Expose this StatsD instance globally? `default: false`
 * `dnsCache`:  Cache the initial dns lookup to *host* `default: false`
+* `mock`:      Create a mock StatsD instance, sending no stats to the server? `default: false`
 
 All StatsD methods have the same API:
 * `name`:       Stat name `required`

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -10,9 +10,10 @@ var dgram = require('dgram'),
  *   @option suffix    {String}  An optional suffix to assign to each stat name sent
  *   @option globalize {boolean} An optional boolean to add "statsd" as an object in the global namespace
  *   @option cacheDns  {boolean} An optional option to only lookup the hostname -> ip address once
+ *   @option mock      {boolean} An optional boolean indicating this Client is a mock object, no stats are sent.
  * @constructor
  */
-var Client = function (host, port, prefix, suffix, globalize, cacheDns) {
+var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock) {
   var options = host || {},
          self = this;
 
@@ -23,7 +24,8 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns) {
       prefix    : prefix,
       suffix    : suffix,
       globalize : globalize,
-      cacheDns  : cacheDns
+      cacheDns  : cacheDns,
+      mock      : mock === true
     };
   }
 
@@ -32,6 +34,7 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns) {
   this.prefix = options.prefix || '';
   this.suffix = options.suffix || '';
   this.socket = dgram.createSocket('udp4');
+  this.mock   = options.mock;
 
   if(options.cacheDns === true){
     dns.lookup(options.host, function(err, address, family){
@@ -167,9 +170,13 @@ Client.prototype.send = function (stat, value, type, sampleRate, callback) {
     }
   }
 
-  buf = new Buffer(message);
-  this.socket.send(buf, 0, buf.length, this.port, this.host, callback);
+  // Only send this stat if we're not a mock Client.
+  if(!this.mock) {
+    buf = new Buffer(message);
+    this.socket.send(buf, 0, buf.length, this.port, this.host, callback);
+  } else {
+    callback(null, 0);
+  }
 };
-
 
 exports.StatsD = Client;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 { "name" : "node-statsd"
 , "description" : "node client for Etsy'd StatsD server"
-, "version" : "0.0.5"
+, "version" : "0.0.6"
 , "author" : "Steve Ivy"
 , "contributors": [ "Russ Bradberry <rbradberry@gmail.com>" ]
 , "repository" :


### PR DESCRIPTION
This adds a null StatsD client (with tests), such that one can leave `statsd.*` calls in his/her code, but use a different constructor at startup, and not have any stats go to the server.

I've also fixed some typos in the README.
