### PR TITLE
Don't call callback if not provided when using mock instances

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -175,7 +175,9 @@ Client.prototype.send = function (stat, value, type, sampleRate, callback) {
     buf = new Buffer(message);
     this.socket.send(buf, 0, buf.length, this.port, this.host, callback);
   } else {
-    callback(null, 0);
+    if(typeof callback === 'function'){
+      callback(null, 0);
+    }
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 { "name" : "node-statsd"
 , "description" : "node client for Etsy'd StatsD server"
-, "version" : "0.0.6"
+, "version" : "0.0.7"
 , "author" : "Steve Ivy"
 , "contributors": [ "Russ Bradberry <rbradberry@gmail.com>" ]
 , "repository" :

--- a/test/test_statsd.js
+++ b/test/test_statsd.js
@@ -38,7 +38,16 @@ function assertMockClientMethod(method, finished){
         statsd = new StatsD(address.address, address.port, 'prefix', 'suffix', false, false,
                             /* mock = true */ true),
         socket = dgram.createSocket("udp4"),
-        buf = new Buffer(testFinished);
+        buf = new Buffer(testFinished),
+        callbackThrows = false;
+
+    // Regression test for "undefined is not a function" with missing callback on mock instance.
+    try {
+      statsd[method]('test', 1);
+    } catch(e) {
+      callbackThrows = true;
+    }
+    assert.ok(!callbackThrows);
 
     statsd[method]('test', 1, null, function(error, bytes){
       assert.ok(!error);


### PR DESCRIPTION
When creating a mock instance, if a callback isn't provided, the code fails when it tries to call the callback param:

```
TypeError: undefined is not a function
    at Client.send (/Users/dave/Sites/repos/butter/node_modules/node-statsd/lib/statsd.js:178:5)
    at Client.sendAll (/Users/dave/Sites/repos/butter/node_modules/node-statsd/lib/statsd.js:148:10)
    at Client.increment (/Users/dave/Sites/repos/butter/node_modules/node-statsd/lib/statsd.js:71:8)
```

This fixes patch fixes that case.
