### PR TITLE
Add IPv6 detection

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -1,5 +1,6 @@
 var dgram = require('dgram'),
-    dns   = require('dns');
+    dns   = require('dns'),
+    net   = require('net');
 
 /**
  * The UDP Client for StatsD
@@ -33,13 +34,19 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock) {
   this.port   = options.port || 8125;
   this.prefix = options.prefix || '';
   this.suffix = options.suffix || '';
-  this.socket = dgram.createSocket('udp4');
+  this.family = net.isIP(this.host);
+  this.socket = dgram.createSocket('udp' + this.family);
   this.mock   = options.mock;
 
   if(options.cacheDns === true){
     dns.lookup(options.host, function(err, address, family){
       if(err == null){
         self.host = address;
+        if(family != self.family){
+          self.family = family;
+          this.socket.close();
+          this.socket = dgram.createSocket('udp' + family);
+        }
       }
     });
   }


### PR DESCRIPTION
This adds support for sending UDP stats over IPv6.

Also, when DNS caching is enabled, if a previously configured IPv4 host is detected as IPv6 (or vice-versa), it closes the UDP socket and creates a new one.

Still missing some tests..
