### PR TITLE
Datadog histograms and tags support

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -53,44 +53,48 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock) {
  * Represents the timing stat
  * @param stat {String|Array} The stat(s) to send
  * @param time {Number} The time in milliseconds to send
- * @param sampleRate {Number} The Number of times to sample (0 to 1)
- * @param callback {Function} Callback when message is done being delivered. Optional.
+ * @param sampleRate {Number=} The Number of times to sample (0 to 1)
+ * @param tags {Array=} The Array of tags to add to metrics
+ * @param callback {Function=} Callback when message is done being delivered. Optional.
  */
-Client.prototype.timing = function (stat, time, sampleRate, callback) {
-  this.sendAll(stat, time, 'ms', sampleRate, callback);
+Client.prototype.timing = function (stat, time, sampleRate, tags, callback) {
+  this.sendAll(stat, time, 'ms', sampleRate, tags, callback);
 };
 
 /**
  * Increments a stat by a specified amount
  * @param stat {String|Array} The stat(s) to send
  * @param value The value to send
- * @param sampleRate {Number} The Number of times to sample (0 to 1)
- * @param callback {Function} Callback when message is done being delivered. Optional.
+ * @param sampleRate {Number=} The Number of times to sample (0 to 1)
+ * @param tags {Array=} The Array of tags to add to metrics
+ * @param callback {Function=} Callback when message is done being delivered. Optional.
  */
-Client.prototype.increment = function (stat, value, sampleRate, callback) {
-  this.sendAll(stat, value || 1, 'c', sampleRate, callback);
+Client.prototype.increment = function (stat, value, sampleRate, tags, callback) {
+  this.sendAll(stat, value || 1, 'c', sampleRate, tags, callback);
 };
 
 /**
  * Decrements a stat by a specified amount
  * @param stat {String|Array} The stat(s) to send
  * @param value The value to send
- * @param sampleRate {Number} The Number of times to sample (0 to 1)
- * @param callback {Function} Callback when message is done being delivered. Optional.
+ * @param sampleRate {Number=} The Number of times to sample (0 to 1)
+ * @param tags {Array=} The Array of tags to add to metrics
+ * @param callback {Function=} Callback when message is done being delivered. Optional.
  */
-Client.prototype.decrement = function (stat, value, sampleRate, callback) {
-  this.sendAll(stat, -value || -1, 'c', sampleRate, callback);
+Client.prototype.decrement = function (stat, value, sampleRate, tags, callback) {
+  this.sendAll(stat, -value || -1, 'c', sampleRate, tags, callback);
 };
 
 /**
  * Represents the histogram stat
  * @param stat {String|Array} The stat(s) to send
  * @param value The value to send
- * @param sampleRate {Number} The Number of times to sample (0 to 1)
- * @param callback {Function} Callback when message is done being delivered. Optional.
+ * @param sampleRate {Number=} The Number of times to sample (0 to 1)
+ * @param tags {Array=} The Array of tags to add to metrics
+ * @param callback {Function=} Callback when message is done being delivered. Optional.
  */
-Client.prototype.histogram = function (stat, value, sampleRate, callback) {
-  this.sendAll(stat, value, 'h', sampleRate, callback);
+Client.prototype.histogram = function (stat, value, sampleRate, tags, callback) {
+  this.sendAll(stat, value, 'h', sampleRate, tags, callback);
 };
 
 
@@ -98,37 +102,51 @@ Client.prototype.histogram = function (stat, value, sampleRate, callback) {
  * Gauges a stat by a specified amount
  * @param stat {String|Array} The stat(s) to send
  * @param value The value to send
- * @param sampleRate {Number} The Number of times to sample (0 to 1)
- * @param callback {Function} Callback when message is done being delivered. Optional.
+ * @param sampleRate {Number=} The Number of times to sample (0 to 1)
+ * @param tags {Array=} The Array of tags to add to metrics
+ * @param callback {Function=} Callback when message is done being delivered. Optional.
  */
-Client.prototype.gauge = function (stat, value, sampleRate, callback) {
-  this.sendAll(stat, value, 'g', sampleRate, callback);
+Client.prototype.gauge = function (stat, value, sampleRate, tags, callback) {
+  this.sendAll(stat, value, 'g', sampleRate, tags, callback);
 };
 
 /**
  * Counts unique values by a specified amount
  * @param stat {String|Array} The stat(s) to send
  * @param value The value to send
- * @param sampleRate {Number} The Number of times to sample (0 to 1)
- * @param callback {Function} Callback when message is done being delivered. Optional.
+ * @param sampleRate {Number=} The Number of times to sample (0 to 1)
+ * @param tags {Array=} The Array of tags to add to metrics
+ * @param callback {Function=} Callback when message is done being delivered. Optional.
  */
 Client.prototype.unique =
-Client.prototype.set = function (stat, value, sampleRate, callback) {
-  this.sendAll(stat, value, 's', sampleRate, callback);
+Client.prototype.set = function (stat, value, sampleRate, tags, callback) {
+  this.sendAll(stat, value, 's', sampleRate, tags, callback);
 };
 
 /**
  * Checks if stats is an array and sends all stats calling back once all have sent
  * @param stat {String|Array} The stat(s) to send
  * @param value The value to send
- * @param sampleRate {Number} The Number of times to sample (0 to 1)
- * @param callback {Function} Callback when message is done being delivered. Optional.
+ * @param sampleRate {Number=} The Number of times to sample (0 to 1)
+ * @param tags {Array=} The Array of tags to add to metrics
+ * @param callback {Function=} Callback when message is done being delivered. Optional.
  */
-Client.prototype.sendAll = function(stat, value, type, sampleRate, callback){
+Client.prototype.sendAll = function(stat, value, type, sampleRate, tags, callback){
   var completed = 0,
       calledback = false,
       sentBytes = 0,
       self = this;
+
+  if(sampleRate && typeof sampleRate !== 'number'){
+    callback = tags;
+    tags = sampleRate;
+    sampleRate = undefined;
+  }
+
+  if(tags && !Array.isArray(tags)){
+    callback = tags;
+    tags = undefined;
+  }
 
   /**
    * Gets called once for each callback, when all callbacks return we will
@@ -154,10 +172,10 @@ Client.prototype.sendAll = function(stat, value, type, sampleRate, callback){
 
   if(Array.isArray(stat)){
     stat.forEach(function(item){
-      self.send(item, value, type, sampleRate, onSend);
+      self.send(item, value, type, sampleRate, tags, onSend);
     });
   } else {
-    this.send(stat, value, type, sampleRate, callback);
+    this.send(stat, value, type, sampleRate, tags, callback);
   }
 };
 
@@ -167,9 +185,10 @@ Client.prototype.sendAll = function(stat, value, type, sampleRate, callback){
  * @param value The value to send
  * @param type {String} The type of message to send to statsd
  * @param sampleRate {Number} The Number of times to sample (0 to 1)
+ * @param tags {Array} The Array of tags to add to metrics
  * @param callback {Function} Callback when message is done being delivered. Optional.
  */
-Client.prototype.send = function (stat, value, type, sampleRate, callback) {
+Client.prototype.send = function (stat, value, type, sampleRate, tags, callback) {
   var message = this.prefix + stat + this.suffix + ':' + value + '|' + type,
       buf;
 
@@ -180,6 +199,10 @@ Client.prototype.send = function (stat, value, type, sampleRate, callback) {
       //don't want to send if we don't meet the sample ratio
       return;
     }
+  }
+
+  if(tags && Array.isArray(tags)){
+    message += '|#' + tags.join(',');
   }
 
   // Only send this stat if we're not a mock Client.

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -83,6 +83,18 @@ Client.prototype.decrement = function (stat, value, sampleRate, callback) {
 };
 
 /**
+ * Represents the histogram stat
+ * @param stat {String|Array} The stat(s) to send
+ * @param value The value to send
+ * @param sampleRate {Number} The Number of times to sample (0 to 1)
+ * @param callback {Function} Callback when message is done being delivered. Optional.
+ */
+Client.prototype.histogram = function (stat, value, sampleRate, callback) {
+  this.sendAll(stat, value, 'h', sampleRate, callback);
+};
+
+
+/**
  * Gauges a stat by a specified amount
  * @param stat {String|Array} The stat(s) to send
  * @param value The value to send

--- a/test/test_statsd.js
+++ b/test/test_statsd.js
@@ -221,6 +221,68 @@ describe('StatsD', function(){
     });
   });
 
+  describe('#histogram', function(finished){
+    it('should send proper histogram format without prefix, suffix, sampling and callback', function(finished){
+      udpTest(function(message, server){
+        assert.equal(message, 'test:42|h');
+        server.close();
+        finished();
+      }, function(server){
+        var address = server.address(),
+            statsd = new StatsD(address.address, address.port);
+
+        statsd.histogram('test', 42);
+      });
+    });
+
+    it('should send proper histogram format with prefix, suffix, sampling and callback', function(finished){
+      var called = false;
+      udpTest(function(message, server){
+        assert.equal(message, 'foo.test.bar:42|h|@0.5');
+        assert.equal(called, true);
+        server.close();
+        finished();
+      }, function(server){
+        var address = server.address(),
+            statsd = new StatsD(address.address, address.port, 'foo.', '.bar');
+
+        statsd.histogram('test', 42, 0.5, function(){
+          called = true;
+        });
+      });
+    });
+
+    it('should properly send a and b with the same value', function(finished){
+      var called = 0,
+          messageNumber = 0;
+
+      udpTest(function(message, server){
+        if(messageNumber === 0){
+          assert.equal(message, 'a:42|h');
+          messageNumber += 1;
+        } else {
+          assert.equal(message, 'b:42|h');
+          server.close();
+          finished();
+        }
+      }, function(server){
+        var address = server.address(),
+            statsd = new StatsD(address.address, address.port);
+
+        statsd.histogram(['a', 'b'], 42, null, function(error, bytes){
+          called += 1;
+          assert.ok(called === 1); //ensure it only gets called once
+          assert.equal(error, null);
+          assert.equal(bytes, 12);
+        });
+      });
+    });
+
+    it('should send no histogram stat when a mock Client is used', function(finished){
+      assertMockClientMethod('histogram', finished);
+    });
+  });
+
   describe('#gauge', function(finished){
     it('should send proper gauge format without prefix, suffix, sampling and callback', function(finished){
       udpTest(function(message, server){

--- a/test/test_statsd.js
+++ b/test/test_statsd.js
@@ -173,6 +173,19 @@ describe('StatsD', function(){
       });
     });
 
+    it('should send proper time format with tags', function(finished){
+      udpTest(function(message, server){
+        assert.equal(message, 'test:42|ms|#foo,bar');
+        server.close();
+        finished();
+      }, function(server){
+        var address = server.address(),
+            statsd = new StatsD(address.address, address.port);
+
+        statsd.timing('test', 42, ['foo', 'bar']);
+      });
+    });
+
     it('should send proper time format with prefix, suffix, sampling and callback', function(finished){
       var called = false;
       udpTest(function(message, server){
@@ -232,6 +245,19 @@ describe('StatsD', function(){
             statsd = new StatsD(address.address, address.port);
 
         statsd.histogram('test', 42);
+      });
+    });
+
+    it('should send proper histogram format with tags', function(finished){
+      udpTest(function(message, server){
+        assert.equal(message, 'test:42|h|#foo,bar');
+        server.close();
+        finished();
+      }, function(server){
+        var address = server.address(),
+            statsd = new StatsD(address.address, address.port);
+
+        statsd.histogram('test', 42, ['foo', 'bar']);
       });
     });
 
@@ -297,6 +323,19 @@ describe('StatsD', function(){
       });
     });
 
+    it('should send proper gauge format with tags', function(finished){
+      udpTest(function(message, server){
+        assert.equal(message, 'test:42|g|#foo,bar');
+        server.close();
+        finished();
+      }, function(server){
+        var address = server.address(),
+            statsd = new StatsD(address.address, address.port);
+
+        statsd.gauge('test', 42, ['foo', 'bar']);
+      });
+    });
+
     it('should send proper gauge format with prefix, suffix, sampling and callback', function(finished){
       var called = false;
       udpTest(function(message, server){
@@ -356,6 +395,19 @@ describe('StatsD', function(){
             statsd = new StatsD(address.address, address.port);
 
         statsd.increment('test');
+      });
+    });
+
+    it('should send proper count format with tags', function(finished){
+      udpTest(function(message, server){
+        assert.equal(message, 'test:42|c|#foo,bar');
+        server.close();
+        finished();
+      }, function(server){
+        var address = server.address(),
+            statsd = new StatsD(address.address, address.port);
+
+        statsd.increment('test', 42, ['foo', 'bar']);
       });
     });
 
@@ -421,6 +473,19 @@ describe('StatsD', function(){
       });
     });
 
+    it('should send proper count format with tags', function(finished){
+      udpTest(function(message, server){
+        assert.equal(message, 'test:-42|c|#foo,bar');
+        server.close();
+        finished();
+      }, function(server){
+        var address = server.address(),
+            statsd = new StatsD(address.address, address.port);
+
+        statsd.decrement('test', 42, ['foo', 'bar']);
+      });
+    });
+
     it('should send proper count format with prefix, suffix, sampling and callback', function(finished){
       var called = false;
       udpTest(function(message, server){
@@ -481,6 +546,19 @@ describe('StatsD', function(){
             statsd = new StatsD(address.address, address.port);
 
         statsd.set('test', 42);
+      });
+    });
+
+    it('should send proper set format with tags', function(finished){
+      udpTest(function(message, server){
+        assert.equal(message, 'test:42|s|#foo,bar');
+        server.close();
+        finished();
+      }, function(server){
+        var address = server.address(),
+            statsd = new StatsD(address.address, address.port);
+
+        statsd.set('test', 42, ['foo', 'bar']);
       });
     });
 


### PR DESCRIPTION
Hi.

I added support for datadog [histograms](http://docs.datadoghq.com/guides/metrics/#histograms) and [tags](http://docs.datadoghq.com/guides/metrics/#tags) features.

I partly used [code from Young Han Lee's fork](https://github.com/joybro/node-dogstatsd), but I preserved backward compatibility with existing API.

I added optional `tags` parameter to all functions.

I also allowed users to skip `sampleRate` parameter, passing `tags` or `callback` instead of it.

The only function which is not 100% backward-compatible is `send`, because I thought it internal.

I also marked all optional parameters in docstrings with `=` symbol according to [JSDocs giude](http://usejsdoc.org/tags-type.html).

I added tests for new functionality, but I haven't documented it in `Readme.md` yet.
