### PR TITLE
Add global tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ $ npm install node-statsd
 All initialization parameters are optional.
 
 Parameters (specified as an options hash):
-* `host`:      The host to send stats to `default: localhost`
-* `port`:      The port to send stats to `default: 8125`
-* `prefix`:    What to prefix each stat name with `default: ''`
-* `suffix`:    What to suffix each stat name with `default: ''`
-* `globalize`: Expose this StatsD instance globally? `default: false`
-* `cacheDns`:  Cache the initial dns lookup to *host* `default: false`
-* `mock`:      Create a mock StatsD instance, sending no stats to the server? `default: false`
+* `host`:        The host to send stats to `default: localhost`
+* `port`:        The port to send stats to `default: 8125`
+* `prefix`:      What to prefix each stat name with `default: ''`
+* `suffix`:      What to suffix each stat name with `default: ''`
+* `globalize`:   Expose this StatsD instance globally? `default: false`
+* `cacheDns`:    Cache the initial dns lookup to *host* `default: false`
+* `mock`:        Create a mock StatsD instance, sending no stats to the server? `default: false`
+* `global_tags`: Optional tags that will be added to every metric `default: []`
 
 All StatsD methods have the same API:
 * `name`:       Stat name `required`

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -4,37 +4,40 @@ var dgram = require('dgram'),
 /**
  * The UDP Client for StatsD
  * @param options
- *   @option host      {String}  The host to connect to default: localhost
- *   @option port      {String|Integer} The port to connect to default: 8125
- *   @option prefix    {String}  An optional prefix to assign to each stat name sent
- *   @option suffix    {String}  An optional suffix to assign to each stat name sent
- *   @option globalize {boolean} An optional boolean to add "statsd" as an object in the global namespace
- *   @option cacheDns  {boolean} An optional option to only lookup the hostname -> ip address once
- *   @option mock      {boolean} An optional boolean indicating this Client is a mock object, no stats are sent.
+ *   @option host        {String}  The host to connect to default: localhost
+ *   @option port        {String|Integer} The port to connect to default: 8125
+ *   @option prefix      {String}  An optional prefix to assign to each stat name sent
+ *   @option suffix      {String}  An optional suffix to assign to each stat name sent
+ *   @option globalize   {boolean} An optional boolean to add "statsd" as an object in the global namespace
+ *   @option cacheDns    {boolean} An optional option to only lookup the hostname -> ip address once
+ *   @option mock        {boolean} An optional boolean indicating this Client is a mock object, no stats are sent.
+ *   @option global_tags {Array=} Optional tags that will be added to every metric
  * @constructor
  */
-var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock) {
+var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, global_tags) {
   var options = host || {},
          self = this;
 
   if(arguments.length > 1 || typeof(host) === 'string'){
     options = {
-      host      : host,
-      port      : port,
-      prefix    : prefix,
-      suffix    : suffix,
-      globalize : globalize,
-      cacheDns  : cacheDns,
-      mock      : mock === true
+      host        : host,
+      port        : port,
+      prefix      : prefix,
+      suffix      : suffix,
+      globalize   : globalize,
+      cacheDns    : cacheDns,
+      mock        : mock === true,
+      global_tags : global_tags
     };
   }
 
-  this.host   = options.host || 'localhost';
-  this.port   = options.port || 8125;
-  this.prefix = options.prefix || '';
-  this.suffix = options.suffix || '';
-  this.socket = dgram.createSocket('udp4');
-  this.mock   = options.mock;
+  this.host        = options.host || 'localhost';
+  this.port        = options.port || 8125;
+  this.prefix      = options.prefix || '';
+  this.suffix      = options.suffix || '';
+  this.socket      = dgram.createSocket('udp4');
+  this.mock        = options.mock;
+  this.global_tags = options.global_tags || [];
 
   if(options.cacheDns === true){
     dns.lookup(options.host, function(err, address, family){
@@ -190,7 +193,8 @@ Client.prototype.sendAll = function(stat, value, type, sampleRate, tags, callbac
  */
 Client.prototype.send = function (stat, value, type, sampleRate, tags, callback) {
   var message = this.prefix + stat + this.suffix + ':' + value + '|' + type,
-      buf;
+      buf,
+      merged_tags = [];
 
   if(sampleRate && sampleRate < 1){
     if(Math.random() < sampleRate){
@@ -202,7 +206,13 @@ Client.prototype.send = function (stat, value, type, sampleRate, tags, callback)
   }
 
   if(tags && Array.isArray(tags)){
-    message += '|#' + tags.join(',');
+    merged_tags = merged_tags.concat(tags);
+  }
+  if(this.global_tags && Array.isArray(this.global_tags)){
+    merged_tags = merged_tags.concat(this.global_tags);
+  }
+  if(merged_tags.length > 0){
+    message += '|#' + merged_tags.join(',');
   }
 
   // Only send this stat if we're not a mock Client.


### PR DESCRIPTION
This PR adds the ability to set global tags when creating the client. These tags will be added to all metrics delivered by the client.
