### PR TITLE
using options object and handle error inside module when handleError …

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -3,7 +3,7 @@ var dgram = require('dgram'),
 
 /**
  * The UDP Client for StatsD
- * @param options
+ * @object options
  *   @option host        {String}  The host to connect to default: localhost
  *   @option port        {String|Integer} The port to connect to default: 8125
  *   @option prefix      {String}  An optional prefix to assign to each stat name sent
@@ -12,38 +12,35 @@ var dgram = require('dgram'),
  *   @option cacheDns    {boolean} An optional option to only lookup the hostname -> ip address once
  *   @option mock        {boolean} An optional boolean indicating this Client is a mock object, no stats are sent.
  *   @option global_tags {Array=} Optional tags that will be added to every metric
+ *   @option handleErrors {boolean} An optional option to handle errors inside statsd
  * @constructor
  */
-var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, global_tags) {
-  var options = host || {},
-         self = this;
-
-  if(arguments.length > 1 || typeof(host) === 'string'){
-    options = {
-      host        : host,
-      port        : port,
-      prefix      : prefix,
-      suffix      : suffix,
-      globalize   : globalize,
-      cacheDns    : cacheDns,
-      mock        : mock === true,
-      global_tags : global_tags
-    };
+var Client = function (options) {
+  var self = this;
+  if (!options) {
+    options = {};
   }
 
-  this.host        = options.host || 'localhost';
-  this.port        = options.port || 8125;
-  this.prefix      = options.prefix || '';
-  this.suffix      = options.suffix || '';
+  this.host        = options.host ? options.host : 'localhost';
+  this.port        = options.port ? options.port : 8125;
+  this.prefix      = options.prefix ? options.prefix : '';
+  this.suffix      = options.suffix ? options.suffix : '';
   this.socket      = dgram.createSocket('udp4');
-  this.mock        = options.mock;
-  this.global_tags = options.global_tags || [];
+  this.mock        = options.mock ? options.mock : false;
+  this.global_tags = options.global_tags ? options.global_tags : [];
 
   if(options.cacheDns === true){
     dns.lookup(options.host, function(err, address, family){
       if(err == null){
         self.host = address;
       }
+    });
+  }
+
+  if (options.handleErrors === true) {
+    this.socket.on("error", function(err) {
+      console.log('\nError Handler:');
+      console.error(err);
     });
   }
 


### PR DESCRIPTION
1. change options to an object.
2. add handleError (we had issue on production)

the issue was that one of our statsd server url was change and the whole app crash 
{ [Error: getaddrinfo ENOTFOUND] code: 'ENOTFOUND', errno: 'ENOTFOUND', syscall: 'getaddrinfo' }

I fix it using domain but that's seems like a good solution that you could listen to the socket and disable it from returning an error.
