### PR TITLE
Added thrown error when cacheDNS flag fails to resolve dns name

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -43,6 +43,8 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
     dns.lookup(options.host, function(err, address, family){
       if(err == null){
         self.host = address;
+      } else {
+        throw new Error(err);
       }
     });
   }


### PR DESCRIPTION
Hello! Some justification for this throw:

Currently if the user passes a hostname to options.host without the cache flag on, the module will try to resolve the DNS name during runtime when the user tries to use any statsd function. The issue here is that if the DNS server cannot be reached, the server will crash.

The cacheDns flag allows an elegant way to allow users to opt out of this behavior. As long as the DNS name was successfully resolved when the module is initialized, the module will not cause the application to crash if DNS is not reachable.

To further reinforce this behavior, I think the the cacheDns lookup should immediately throw if the user passes an invalid hostname during initialization.
