### PR TITLE
Exclusive dgram bind to avoid cluster exceptions

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -39,11 +39,6 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
   this.mock        = options.mock;
   this.global_tags = options.global_tags || [];
 
-  this.socket.bind({
-    port      : 0,
-    exclusive : true
-  }, null);
-
   if(options.cacheDns === true){
     dns.lookup(options.host, function(err, address, family){
       if(err == null){
@@ -223,6 +218,12 @@ Client.prototype.send = function (stat, value, type, sampleRate, tags, callback)
   // Only send this stat if we're not a mock Client.
   if(!this.mock) {
     buf = new Buffer(message);
+    if(this.socket._bindState === 0){
+      this.socket.bind({
+        port      : 0,
+        exclusive : true
+      }, null);
+    }
     this.socket.send(buf, 0, buf.length, this.port, this.host, callback);
   } else {
     if(typeof callback === 'function'){

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -39,6 +39,11 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
   this.mock        = options.mock;
   this.global_tags = options.global_tags || [];
 
+  this.socket.bind({
+    port      : 0,
+    exclusive : true
+  }, null);
+
   if(options.cacheDns === true){
     dns.lookup(options.host, function(err, address, family){
       if(err == null){


### PR DESCRIPTION
This fixes #56
The dgram socket is bound to an exclusive port to avoid crashes.
Will work in node versions >0.11.14

Based on: https://github.com/joyent/node/pull/8643
