### PR TITLE
Add ability to aggregate packets for sending

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -12,9 +12,11 @@ var dgram = require('dgram'),
  *   @option cacheDns    {boolean} An optional option to only lookup the hostname -> ip address once
  *   @option mock        {boolean} An optional boolean indicating this Client is a mock object, no stats are sent.
  *   @option global_tags {Array=} Optional tags that will be added to every metric
+ *   @maxBufferSize      {Number} An optional value for aggregating metrics to send, mainly for performance improvement
+ *   @bufferFlushInterval {Number} the time out value to flush out buffer if not
  * @constructor
  */
-var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, global_tags) {
+var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, global_tags, maxBufferSize, bufferFlushInterval) {
   var options = host || {},
          self = this;
 
@@ -29,7 +31,7 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
       mock        : mock === true,
       global_tags : global_tags,
       maxBufferSize : maxBufferSize,
-      bufferFlushInterval: bufferFlushInteral
+      bufferFlushInterval: bufferFlushInterval
     };
   }
 
@@ -45,7 +47,7 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
   this.buffer = "";
 
   if(this.maxBufferSize > 0) {
-      setInterval(this.timeoutCallback.bind(this), this.bufferFlushInterval);
+    this.intervalHandle = setInterval(this.timeoutCallback.bind(this), this.bufferFlushInterval);
   }
 
   if(options.cacheDns === true){
@@ -227,47 +229,67 @@ Client.prototype.send = function (stat, value, type, sampleRate, tags, callback)
   // Only send this stat if we're not a mock Client.
   if(!this.mock) {
       if(this.maxBufferSize === 0) {
-          this.sendMessage(message);
+          this.sendMessage(message, callback);
       }
       else {
           this.enqueue(message);
       }
-  } else {
+  }
+  else {
     if(typeof callback === 'function'){
       callback(null, 0);
     }
   }
 };
 
+/**
+ *
+ * @param message {String}
+ */
 Client.prototype.enqueue = function(message){
-    this.buffer += message + "\n";
-    if(this.buffer.length > this.maxBufferSize) {
-        this.flushQueue();
-    }
+  this.buffer += message + "\n";
+  if(this.buffer.length > this.maxBufferSize) {
+      this.flushQueue();
+  }
 }
 
+/**
+ *
+ */
 Client.prototype.flushQueue = function(){
-    this.sendMessage(this.buffer);
-    this.buffer = "";
+  this.sendMessage(this.buffer);
+  this.buffer = "";
 }
 
-Client.prototype.sendMessage = function(message){
-    buf = new Buffer(message);
-    this.socket.send(buf, 0, buf.length, this.port, this.host);
+/**
+ *
+ * @param message {String}
+ * @param callback {Function}
+ */
+Client.prototype.sendMessage = function(message, callback){
+  buf = new Buffer(message);
+  this.socket.send(buf, 0, buf.length, this.port, this.host, callback);
 }
 
+/**
+ *
+ */
 Client.prototype.timeoutCallback = function(){
-    if(this.buffer !== "") {
-        this.flushQueue();
-    }
+  if(this.buffer !== "") {
+    this.flushQueue();
+  }
 }
 
 /**
  * Close the underlying socket and stop listening for data on it.
  */
 Client.prototype.close = function(){
-    this.socket.close();
+  if(this.intervalHandle) {
+    clearInterval(this.intervalHandle);
+  }
+  this.socket.close();
 }
 
 exports = module.exports = Client;
 exports.StatsD = Client;
+

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -27,7 +27,9 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
       globalize   : globalize,
       cacheDns    : cacheDns,
       mock        : mock === true,
-      global_tags : global_tags
+      global_tags : global_tags,
+      maxBufferSize : maxBufferSize,
+      bufferFlushInterval: bufferFlushInteral
     };
   }
 
@@ -38,6 +40,13 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
   this.socket      = dgram.createSocket('udp4');
   this.mock        = options.mock;
   this.global_tags = options.global_tags || [];
+  this.maxBufferSize = options.maxBufferSize || 0;
+  this.bufferFlushInterval = options.bufferFlushInterval || 1000;
+  this.buffer = "";
+
+  if(this.maxBufferSize > 0) {
+      setInterval(this.timeoutCallback.bind(this), this.bufferFlushInterval);
+  }
 
   if(options.cacheDns === true){
     dns.lookup(options.host, function(err, address, family){
@@ -217,14 +226,41 @@ Client.prototype.send = function (stat, value, type, sampleRate, tags, callback)
 
   // Only send this stat if we're not a mock Client.
   if(!this.mock) {
-    buf = new Buffer(message);
-    this.socket.send(buf, 0, buf.length, this.port, this.host, callback);
+      if(this.maxBufferSize === 0) {
+          this.sendMessage(message);
+      }
+      else {
+          this.enqueue(message);
+      }
   } else {
     if(typeof callback === 'function'){
       callback(null, 0);
     }
   }
 };
+
+Client.prototype.enqueue = function(message){
+    this.buffer += message + "\n";
+    if(this.buffer.length > this.maxBufferSize) {
+        this.flushQueue();
+    }
+}
+
+Client.prototype.flushQueue = function(){
+    this.sendMessage(this.buffer);
+    this.buffer = "";
+}
+
+Client.prototype.sendMessage = function(message){
+    buf = new Buffer(message);
+    this.socket.send(buf, 0, buf.length, this.port, this.host);
+}
+
+Client.prototype.timeoutCallback = function(){
+    if(this.buffer !== "") {
+        this.flushQueue();
+    }
+}
 
 /**
  * Close the underlying socket and stop listening for data on it.

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -204,7 +204,6 @@ Client.prototype.sendAll = function(stat, value, type, sampleRate, tags, callbac
  */
 Client.prototype.send = function (stat, value, type, sampleRate, tags, callback) {
   var message = this.prefix + stat + this.suffix + ':' + value + '|' + type,
-      buf,
       merged_tags = [];
 
   if(sampleRate && sampleRate < 1){
@@ -248,7 +247,7 @@ Client.prototype.send = function (stat, value, type, sampleRate, tags, callback)
  */
 Client.prototype.enqueue = function(message){
   this.buffer += message + "\n";
-  if(this.buffer.length > this.maxBufferSize) {
+  if(this.buffer.length >= this.maxBufferSize) {
       this.flushQueue();
   }
 }
@@ -267,7 +266,7 @@ Client.prototype.flushQueue = function(){
  * @param callback {Function}
  */
 Client.prototype.sendMessage = function(message, callback){
-  buf = new Buffer(message);
+  var buf = new Buffer(message);
   this.socket.send(buf, 0, buf.length, this.port, this.host, callback);
 }
 

--- a/perfTest/test.js
+++ b/perfTest/test.js
@@ -1,7 +1,7 @@
-var statsD = require('node-statsd');
+var statsD = require('../lib/statsd');
 var count = 0;
 var options = {
-    maxBufferSize: 0
+    maxBufferSize: process.argv[2]
 };
 var statsd = new statsD(options);
 
@@ -10,19 +10,12 @@ var start = new Date();
 function sendPacket() {
     count++;
     statsd.increment('abc.cde.efg.ghk.klm', 1);
-    //process.nextTick(sendPacket);
-    if(count %1000000 ===  0) {
+    if(count %100000 ===  0) {
         var stop = new Date();
         console.log(stop - start);
         start = stop;
     }
     setImmediate(sendPacket);
-}
-
-function counting() {
-    console.log(count);
-    count = 0;
-    setInterval(counting, 10000);
 }
 
 sendPacket();

--- a/test.js
+++ b/test.js
@@ -1,0 +1,28 @@
+var statsD = require('node-statsd');
+var count = 0;
+var options = {
+    maxBufferSize: 0
+};
+var statsd = new statsD(options);
+
+var start = new Date();
+
+function sendPacket() {
+    count++;
+    statsd.increment('abc.cde.efg.ghk.klm', 1);
+    //process.nextTick(sendPacket);
+    if(count %1000000 ===  0) {
+        var stop = new Date();
+        console.log(stop - start);
+        start = stop;
+    }
+    setImmediate(sendPacket);
+}
+
+function counting() {
+    console.log(count);
+    count = 0;
+    setInterval(counting, 10000);
+}
+
+sendPacket();


### PR DESCRIPTION
This ports the functionality from https://github.com/msiebuhr/node-statsd-client for aggregated packets. 

It shows great performance improvement.  I ran perfTest/test.js to measure the time required of sending out 100,000 packets. A buffer size of 1200 is 5 times faster than no buffering.
 ==> node test.js 0
2143
2126
2186
2281
2487
1941
3006
2026
2909
2042
2049
^C

 ==> node test.js 1200
395
389
385
388
393
389
390
388
389
391
388
389
^C

 ==> node test.js 200
757
794
763
814
772
799
782
779
785
815
^C
