### PR TITLE
Add newer versions of node to the tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
   - "0.6"
   - "0.8"
   - "0.10"
+  - "v4"
+  - "node"
 
 install:
   - npm install


### PR DESCRIPTION
Adding 'node' to the test list will tell travis (which uses `nvm`) to download and install the most recent version of node available.
