### PR TITLE
Support incrementing or decrementing Counters by 0

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -73,7 +73,9 @@ Client.prototype.timing = function (stat, time, sampleRate, tags, callback) {
  * @param callback {Function=} Callback when message is done being delivered. Optional.
  */
 Client.prototype.increment = function (stat, value, sampleRate, tags, callback) {
-  this.sendAll(stat, value || 1, 'c', sampleRate, tags, callback);
+  value = (value === undefined || value === null) ? 1 : value;
+
+  this.sendAll(stat, value, 'c', sampleRate, tags, callback);
 };
 
 /**
@@ -85,7 +87,9 @@ Client.prototype.increment = function (stat, value, sampleRate, tags, callback) 
  * @param callback {Function=} Callback when message is done being delivered. Optional.
  */
 Client.prototype.decrement = function (stat, value, sampleRate, tags, callback) {
-  this.sendAll(stat, -value || -1, 'c', sampleRate, tags, callback);
+  value = (value === undefined || value === null) ? 1 : value;
+
+  this.sendAll(stat, -value, 'c', sampleRate, tags, callback);
 };
 
 /**

--- a/test/test_statsd.js
+++ b/test/test_statsd.js
@@ -527,6 +527,19 @@ describe('StatsD', function(){
     it('should send no increment stat when a mock Client is used', function(finished){
       assertMockClientMethod('increment', finished);
     });
+
+    it('should send 0 when value is 0', function(finished){
+        udpTest(function(message, server){
+        assert.equal(message, 'test:0|c');
+        server.close();
+        finished();
+      }, function(server){
+        var address = server.address(),
+            statsd = new StatsD(address.address, address.port);
+
+        statsd.increment('test', 0);
+      });
+    });
   });
 
   describe('#decrement', function(finished){
@@ -602,6 +615,19 @@ describe('StatsD', function(){
 
     it('should send no decrement stat when a mock Client is used', function(finished){
       assertMockClientMethod('decrement', finished);
+    });
+
+    it('should send 0 when value is 0', function(finished){
+        udpTest(function(message, server){
+        assert.equal(message, 'test:0|c');
+        server.close();
+        finished();
+      }, function(server){
+        var address = server.address(),
+            statsd = new StatsD(address.address, address.port);
+
+        statsd.decrement('test', 0);
+      });
     });
   });
 


### PR DESCRIPTION
We need to be able to support incrementing or decrementing a Counter by 0. The current code `value || 1` where `value = 0` will always evaluate to 1. This changes the behavior to support 0, but still default to 1 when `value` is `undefined` or `null`.