### PR TITLE
Add support for TCP connections (as introduced in etsy/statsd@v0.8.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: node_js
 
 node_js:
-  - "0.6"
-  - "0.8"
   - "0.10"
+  - "0.11"
+  - "0.12"
+  - "4"
+  - "5"
+  - "6"
+  - "7"
 
 install:
   - npm install

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A node.js client for [Etsy](http://etsy.com)'s [StatsD](https://github.com/etsy/
 
 This client will let you fire stats at your StatsD server from a node.js application.
 
-node-statsd Runs and is tested on Node 0.6+ on all *nix platforms and 0.8+ on all platforms including Windows.
+node-statsd Runs and is tested on Node 0.10+ on all platforms including Windows.
 
 [![Build Status](https://secure.travis-ci.org/sivy/node-statsd.png?branch=master)](http://travis-ci.org/sivy/node-statsd)
 
@@ -27,6 +27,7 @@ Parameters (specified as an options hash):
 * `cacheDns`:    Cache the initial dns lookup to *host* `default: false`
 * `mock`:        Create a mock StatsD instance, sending no stats to the server? `default: false`
 * `global_tags`: Optional tags that will be added to every metric `default: []`
+* `tcp`:         Optional boolean indicating if the Client should use a TCP connection `default: false`
 
 All StatsD methods have the same API:
 * `name`:       Stat name `required`

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -1,4 +1,5 @@
 var dgram = require('dgram'),
+    net = require('net'),
     dns   = require('dns');
 
 /**
@@ -12,9 +13,10 @@ var dgram = require('dgram'),
  *   @option cacheDns    {boolean} An optional option to only lookup the hostname -> ip address once
  *   @option mock        {boolean} An optional boolean indicating this Client is a mock object, no stats are sent.
  *   @option global_tags {Array=} Optional tags that will be added to every metric
+ *   @option tcp         {boolean} An optional boolean indicating if the Client should use a TCP connection
  * @constructor
  */
-var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, global_tags) {
+var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, global_tags, tcp) {
   var options = host || {},
          self = this;
 
@@ -27,7 +29,8 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
       globalize   : globalize,
       cacheDns    : cacheDns,
       mock        : mock === true,
-      global_tags : global_tags
+      global_tags : global_tags,
+      tcp         : tcp
     };
   }
 
@@ -35,9 +38,10 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
   this.port        = options.port || 8125;
   this.prefix      = options.prefix || '';
   this.suffix      = options.suffix || '';
-  this.socket      = dgram.createSocket('udp4');
+  this.socket      = options.tcp ? net.connect(this.port, this.host) : dgram.createSocket('udp4');
   this.mock        = options.mock;
   this.global_tags = options.global_tags || [];
+  this.tcp         = options.tcp;
 
   if(options.cacheDns === true){
     dns.lookup(options.host, function(err, address, family){
@@ -49,6 +53,13 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
 
   if(options.globalize){
     global.statsd = this;
+  }
+
+  if(options.tcp === true) {
+    // Catch global TCP connection errors
+    // We don't have a way to get them to the consumer, so just discard them
+    this.socket.on('error', function() {});
+    this.socket.setKeepAlive(true);
   }
 };
 
@@ -167,7 +178,10 @@ Client.prototype.sendAll = function(stat, value, type, sampleRate, tags, callbac
       return callback(error);
     }
 
-    sentBytes += bytes;
+    if(bytes) {
+      sentBytes += bytes;
+    }
+
     if(completed === stat.length){
       callback(null, sentBytes);
     }
@@ -215,10 +229,28 @@ Client.prototype.send = function (stat, value, type, sampleRate, tags, callback)
     message += '|#' + merged_tags.join(',');
   }
 
+  if(this.tcp) {
+    message += '\n';
+  }
+
+  this.sendRaw(message, callback);
+}
+
+/**
+ * Sends a stat across the wire
+ * @param message {String} The fully qualified stat to send [prefix]stat[suffix]:value|type[|@sampleRate][|#tags]
+ * @param callback {Function=} Callback when message is done being delivered. Optional.
+ */
+Client.prototype.sendRaw = function (message, callback) {
+
   // Only send this stat if we're not a mock Client.
   if(!this.mock) {
     buf = new Buffer(message);
-    this.socket.send(buf, 0, buf.length, this.port, this.host, callback);
+    if(this.tcp) {
+      this.socket.write(buf, 'ascii', callback);
+    } else {
+      this.socket.send(buf, 0, buf.length, this.port, this.host, callback);
+    }
   } else {
     if(typeof callback === 'function'){
       callback(null, 0);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   }
 , "bugs" : { "url" : "https://github.com/sivy/node-statsd/issues" }
 , "directories" : { "lib" : "./lib/" }
-, "engines" : { "node" : ">=0.1.97" }
+, "engines" : { "node" : ">=0.10" }
 , "scripts": {
       "test": "mocha -R spec"
     }


### PR DESCRIPTION
This PR adds support for TCP connections, which was included in the `etsy/statsd` library in version 0.8.0 (current). It adds a boolean 'tcp' option. If set to true, it will create a net.Socket connection with keepAlive enabled to the specified host/port. Stats are written to the TCP socket for processing by Statsd.

The unit tests have been updated to also include a TCP server test, with TCP server implementation taken from `etsy/statsd`.