### PR TITLE
add support for grouping messages in on UDP requests

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -12,9 +12,11 @@ var dgram = require('dgram'),
  *   @option cacheDns    {boolean} An optional option to only lookup the hostname -> ip address once
  *   @option mock        {boolean} An optional boolean indicating this Client is a mock object, no stats are sent.
  *   @option global_tags {Array=} Optional tags that will be added to every metric
+ *   @option groupTime   {Number} An optional number for grouping all requests in a timeframe
+ *   @option maxGroupSize{Number} An optional number for max packet sieze if grouping is used
  * @constructor
  */
-var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, global_tags) {
+var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, global_tags, groupTime, maxGroupSize) {
   var options = host || {},
          self = this;
 
@@ -27,7 +29,9 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
       globalize   : globalize,
       cacheDns    : cacheDns,
       mock        : mock === true,
-      global_tags : global_tags
+      global_tags : global_tags,
+      groupTime   : groupTime,
+      maxGroupSize: maxGroupSize
     };
   }
 
@@ -38,6 +42,9 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
   this.socket      = dgram.createSocket('udp4');
   this.mock        = options.mock;
   this.global_tags = options.global_tags || [];
+  this.groupTime   = options.groupTime || 0;
+  this.maxGroupSize= options.maxGroupSize || 1300;
+
 
   if(options.cacheDns === true){
     dns.lookup(options.host, function(err, address, family){
@@ -193,7 +200,6 @@ Client.prototype.sendAll = function(stat, value, type, sampleRate, tags, callbac
  */
 Client.prototype.send = function (stat, value, type, sampleRate, tags, callback) {
   var message = this.prefix + stat + this.suffix + ':' + value + '|' + type,
-      buf,
       merged_tags = [];
 
   if(sampleRate && sampleRate < 1){
@@ -217,8 +223,35 @@ Client.prototype.send = function (stat, value, type, sampleRate, tags, callback)
 
   // Only send this stat if we're not a mock Client.
   if(!this.mock) {
-    buf = new Buffer(message);
-    this.socket.send(buf, 0, buf.length, this.port, this.host, callback);
+      if(typeof callback !== 'function' && this.groupTime > 0){
+          if(!this.send_message) {
+              this.send_message = message;
+          } else {
+              var newSize = (this.send_message.length + 1 + message.length);
+              if(newSize > this.maxGroupSize) {
+                   var buf = new Buffer(this.send_message);
+                   this.send_message = message;
+                   this.socket.send(buf, 0, buf.length, this.port, this.host, callback);
+              } else {
+                  this.send_message += "\n" + message;
+              }
+          }
+
+          if(!this.timmer_running) {
+              var self = this;
+              function send_timer() {
+                  var buf = new Buffer(self.send_message);
+                  self.send_message = undefined;
+                  self.timmer_running = false;
+                  self.socket.send(buf, 0, buf.length, self.port, self.host, callback);
+              }
+              setTimeout(send_timer, this.groupTime);
+              this.timmer_running = true;
+          }
+      } else {
+          var buf = new Buffer(message);
+          this.socket.send(buf, 0, buf.length, this.port, this.host, callback);
+      }
   } else {
     if(typeof callback === 'function'){
       callback(null, 0);


### PR DESCRIPTION
this is very helpful if many data points are send over the Network.
In my use case reducing the UDP packets send by 19 times