### PR TITLE
Client: Constructor supports createSocket option

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -12,9 +12,10 @@ var dgram = require('dgram'),
  *   @option cacheDns    {boolean} An optional option to only lookup the hostname -> ip address once
  *   @option mock        {boolean} An optional boolean indicating this Client is a mock object, no stats are sent.
  *   @option global_tags {Array=} Optional tags that will be added to every metric
+ *   @option createSocket {Function} Optional function that will be used to initialize the client's socket
  * @constructor
  */
-var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, global_tags) {
+var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, global_tags, createSocket) {
   var options = host || {},
          self = this;
 
@@ -27,15 +28,21 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
       globalize   : globalize,
       cacheDns    : cacheDns,
       mock        : mock === true,
-      global_tags : global_tags
+      global_tags : global_tags,
+      createSocket: createSocket
     };
+  }
+
+  var createSocket = dgram.createSocket.bind(null, 'udp4');
+  if (typeof options.createSocket === 'function') {
+    createSocket = options.createSocket;
   }
 
   this.host        = options.host || 'localhost';
   this.port        = options.port || 8125;
   this.prefix      = options.prefix || '';
   this.suffix      = options.suffix || '';
-  this.socket      = dgram.createSocket('udp4');
+  this.socket      = createSocket();
   this.mock        = options.mock;
   this.global_tags = options.global_tags || [];
 

--- a/test/test_statsd.js
+++ b/test/test_statsd.js
@@ -178,6 +178,15 @@ describe('StatsD', function(){
       assert.ok(statsd.socket instanceof dgram.Socket);
     });
 
+    it('should create a socket when custom createSocket function is provided in options', function(){
+      var statsd = new StatsD({
+        createSocket: function() {
+          return 'customSocket';
+        }
+      });
+      assert.equal('customSocket', statsd.socket);
+    });
+
   });
 
   describe('#global_tags', function(){


### PR DESCRIPTION
Refs #77 

This change allows clients to configure a custom `createSocket` method to use for socket construction.  The example below shows how clients on newer versions of node, with statsd daemons running locally, could provide a socket constructor to bypass DNS lookups:

```
var statsd = new StatsD({
        createSocket: function() {
          return dgram.createSocket({
              type: 'udp4',
              lookup: function() { 
                const cb = arguments[arguments.length -1];
                cb(null, '127.0.0.1', 4);
              }
          });
        }
      });
```

This is useful to allow 